### PR TITLE
Implement basic file type detection

### DIFF
--- a/cmd/main/filetype.go
+++ b/cmd/main/filetype.go
@@ -1,0 +1,52 @@
+package main
+
+import "strings"
+
+func hasExtension(path string, exts []string) bool {
+	for _, ext := range exts {
+		if strings.HasSuffix(path, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+func IsTextFile(path string) bool {
+	exts := []string{".txt", ".md", ".csv", ".log"}
+	return hasExtension(path, exts)
+}
+
+func IsImageFile(path string) bool {
+	exts := []string{".jpg", ".jpeg", ".png", ".gif", ".bmp", ".svg", ".webp"}
+	return hasExtension(path, exts)
+}
+
+func IsAudioFile(path string) bool {
+	exts := []string{".mp3", ".wav", ".ogg", ".flac", ".aac"}
+	return hasExtension(path, exts)
+}
+
+func IsVideoFile(path string) bool {
+	exts := []string{".mp4", ".avi", ".mov", ".wmv", ".flv", ".mkv"}
+	return hasExtension(path, exts)
+}
+
+func IsDocumentFile(path string) bool {
+	exts := []string{".pdf", ".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx"}
+	return hasExtension(path, exts)
+}
+
+func IsScriptFile(path string) bool {
+	exts := []string{".sh", ".bat", ".ps1", ".py", ".rb", ".pl", ".js", ".ts"}
+	return hasExtension(path, exts)
+}
+
+func IsExecutableFile(path string) bool {
+	exts := []string{".exe", ".dll", ".so", ".bin", ".app"}
+	return hasExtension(path, exts)
+}
+
+func IsArchiveFile(path string) bool {
+	exts := []string{".zip", ".tar", ".gz", ".bz2", ".rar", ".7z", ".xz", ".tar.gz", ".tar.bz2", ".tar.xz", ".tgz", ".tbz2", ".lz", ".lzma", ".z", ".cab", ".arj", ".war", ".ear"}
+	return hasExtension(path, exts)
+}

--- a/cmd/main/main_test.go
+++ b/cmd/main/main_test.go
@@ -15,7 +15,8 @@ func TestIsTextFile(t *testing.T) {
 		given string // 入力ファイル名
 		want  bool   // 期待値
 	}{
-		// テストケースはここに追加
+		{"readme.txt", true},
+		{"image.jpg", false},
 	}
 
 	for _, tc := range testCases {
@@ -31,7 +32,8 @@ func TestIsImageFile(t *testing.T) {
 		given string // 入力ファイル名
 		want  bool   // 期待値
 	}{
-		// テストケースはここに追加
+		{"photo.jpg", true},
+		{"document.txt", false},
 	}
 
 	for _, tc := range testCases {
@@ -47,7 +49,8 @@ func TestIsAudioFile(t *testing.T) {
 		given string // 入力ファイル名
 		want  bool   // 期待値
 	}{
-		// テストケースはここに追加
+		{"sound.ogg", true},
+		{"movie.mp4", false},
 	}
 
 	for _, tc := range testCases {
@@ -63,7 +66,8 @@ func TestIsVideoFile(t *testing.T) {
 		given string // 入力ファイル名
 		want  bool   // 期待値
 	}{
-		// テストケースはここに追加
+		{"movie.mp4", true},
+		{"song.mp3", false},
 	}
 
 	for _, tc := range testCases {
@@ -79,7 +83,8 @@ func TestIsDocumentFile(t *testing.T) {
 		given string // 入力ファイル名
 		want  bool   // 期待値
 	}{
-		// テストケースはここに追加
+		{"report.pdf", true},
+		{"script.py", false},
 	}
 
 	for _, tc := range testCases {
@@ -95,7 +100,8 @@ func TestIsScriptFile(t *testing.T) {
 		given string // 入力ファイル名
 		want  bool   // 期待値
 	}{
-		// テストケースはここに追加
+		{"script.py", true},
+		{"document.pdf", false},
 	}
 
 	for _, tc := range testCases {
@@ -111,7 +117,8 @@ func TestIsExecutableFile(t *testing.T) {
 		given string // 入力ファイル名
 		want  bool   // 期待値
 	}{
-		// テストケースはここに追加
+		{"program.exe", true},
+		{"build.sh", false},
 	}
 
 	for _, tc := range testCases {
@@ -127,7 +134,8 @@ func TestIsArchiveFile(t *testing.T) {
 		given string // 入力ファイル名
 		want  bool   // 期待値
 	}{
-		// テストケースはここに追加
+		{"archive.zip", true},
+		{"report.pdf", false},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
## Summary
- add `filetype.go` with basic file type detection helpers
- fill in unit tests to cover each detection function

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854bdb5c8f08325a3aa2be38ebe2773