### PR TITLE
Fix CI coverage generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,9 @@ jobs:
         run: cat cmd/main/filetype.go
 
       - name: build and test
-        run: just build
+        run: |
+          just build
+          just test
 
       - name: Convert coverage format to lcov
         uses: jandelgado/gcov2lcov-action@v1.0.9


### PR DESCRIPTION
## Summary
- run tests in CI so coverage.out exists for gcov2lcov

## Testing
- `go test ./...` *(fails: undefined references)*

------
https://chatgpt.com/codex/tasks/task_e_6854bd7f25488325a29d4e734cdea449