### PR TITLE
Fix CI workflow to generate coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,9 @@ jobs:
         run: cat cmd/main/filetype.go
 
       - name: build and test
-        run: just build
+        run: |
+          just build
+          just test
 
       - name: Convert coverage format to lcov
         uses: jandelgado/gcov2lcov-action@v1.0.9


### PR DESCRIPTION
## Summary
- run `just test` so coverage files are created

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854c1ed51c8832599bc3fb49227d9e8