### PR TITLE
Add Dockerfile and container workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -65,3 +65,45 @@ jobs:
         run: |
           just make_distribution_files
           just upload_assets v${{ needs.setup.outputs.tag }}
+
+  docker:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Docker buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=,suffix=,format=short
+            type=raw,value=${{ needs.publish.outputs.tag }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout the project
+        uses: actions/checkout@v4
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from:
+            type=registry,ref=ghcr.io/${{ github.repository}}:buildcache
+          cache-to:
+            type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+# Build stage
+FROM golang:1.21 AS builder
+ARG VERSION
+WORKDIR /src
+COPY . .
+RUN go build -o /work/codepulse ./cmd/main
+
+# Final stage
+FROM scratch
+ARG VERSION
+LABEL org.opencontainers.image.source="https://github.com/miyataSUPER/CodePulse--" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.title="codepulse" \
+      org.opencontainers.image.description="File type classifier"
+RUN adduser --disabled-password --disabled-login --home /workdir nonroot \
+    && mkdir -p /workdir
+COPY --from=builder /work/codepulse /opt/codepulse/codepulse
+COPY --from=golang:1.21 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+WORKDIR /workdir
+USER nonroot
+ENTRYPOINT ["/opt/codepulse/codepulse"]

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,18 @@ go mod tidy
 go build .
 ```
 
+### Dockerイメージの利用
+
+Dockerfile を使ってコンテナイメージをビルド・実行できます。イメージは GHCR (GitHub Container Registry) にも公開されます。
+
+```bash
+# イメージをビルド
+docker build -t codepulse .
+
+# 実行
+docker run --rm codepulse
+```
+
 ## 使用方法
 
 ### デモプログラムの実行


### PR DESCRIPTION
## Summary
- create Dockerfile building CodePulse++ binary and running as nonroot user
- extend publish workflow with Docker image build and push job

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6854c7d4ed948325b3fe2911d39959cc