### PR TITLE
Add file info reporting

### DIFF
--- a/cmd/main/fileinfo.go
+++ b/cmd/main/fileinfo.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"io/fs"
+	"os"
+	"strings"
+)
+
+// FileInfo holds file type, size in bytes, and token count.
+type FileInfo struct {
+	Type   string
+	Size   int64
+	Tokens int
+}
+
+// GetFileType returns the human-readable category for the file based on its extension.
+func GetFileType(path string) string {
+	switch {
+	case IsTextFile(path):
+		return "テキスト"
+	case IsImageFile(path):
+		return "画像"
+	case IsAudioFile(path):
+		return "音声"
+	case IsVideoFile(path):
+		return "動画"
+	case IsDocumentFile(path):
+		return "ドキュメント"
+	case IsScriptFile(path):
+		return "スクリプト"
+	case IsExecutableFile(path):
+		return "実行ファイル"
+	case IsArchiveFile(path):
+		return "アーカイブ"
+	default:
+		return "不明"
+	}
+}
+
+// GetFileInfo reads the file at the given path and returns its type, size, and token count.
+func GetFileInfo(path string) (*FileInfo, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens := 0
+	if len(data) > 0 {
+		tokens = len(strings.Fields(string(data)))
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FileInfo{
+		Type:   GetFileType(path),
+		Size:   info.Size(),
+		Tokens: tokens,
+	}, nil
+}
+
+// helper for tests to create a file with content.
+func createTempFile(dir, pattern, content string) (string, fs.FileInfo, error) {
+	file, err := os.CreateTemp(dir, pattern)
+	if err != nil {
+		return "", nil, err
+	}
+	if _, err := file.WriteString(content); err != nil {
+		file.Close()
+		os.Remove(file.Name())
+		return "", nil, err
+	}
+	if err := file.Close(); err != nil {
+		return "", nil, err
+	}
+	info, err := os.Stat(file.Name())
+	return file.Name(), info, err
+}

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 )
 
 func main() {
@@ -26,30 +27,17 @@ func main() {
 
 	fmt.Println("=== ファイル種別判定デモ ===")
 	for _, filename := range testFiles {
-		fmt.Printf("ファイル名: %-15s => ", filename)
-
-		var fileType string
-		switch {
-		case IsTextFile(filename):
-			fileType = "テキスト"
-		case IsImageFile(filename):
-			fileType = "画像"
-		case IsAudioFile(filename):
-			fileType = "音声"
-		case IsVideoFile(filename):
-			fileType = "動画"
-		case IsDocumentFile(filename):
-			fileType = "ドキュメント"
-		case IsScriptFile(filename):
-			fileType = "スクリプト"
-		case IsExecutableFile(filename):
-			fileType = "実行ファイル"
-		case IsArchiveFile(filename):
-			fileType = "アーカイブ"
-		default:
-			fileType = "不明"
+		info, err := GetFileInfo(filename)
+		if err != nil {
+			// ファイルが存在しない場合は種別のみ表示
+			if os.IsNotExist(err) {
+				fmt.Printf("ファイル名: %-15s => %s (ファイルなし)\n", filename, GetFileType(filename))
+				continue
+			}
+			fmt.Printf("%s の読み込みに失敗しました: %v\n", filename, err)
+			continue
 		}
-
-		fmt.Println(fileType)
+		fmt.Printf("ファイル名: %-15s => %s, サイズ: %d bytes, トークン数: %d\n",
+			filename, info.Type, info.Size, info.Tokens)
 	}
 }

--- a/cmd/main/main_test.go
+++ b/cmd/main/main_test.go
@@ -241,3 +241,22 @@ func ExampleIsArchiveFile() {
 	// true
 	// false
 }
+func TestGetFileInfo(t *testing.T) {
+	path, _, err := createTempFile(t.TempDir(), "sample*.txt", "hello world example")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	info, err := GetFileInfo(path)
+	if err != nil {
+		t.Fatalf("GetFileInfo error: %v", err)
+	}
+	if info.Type != "テキスト" {
+		t.Errorf("Type = %s, want テキスト", info.Type)
+	}
+	if info.Size == 0 {
+		t.Errorf("Size should not be zero")
+	}
+	if info.Tokens != 3 {
+		t.Errorf("Tokens = %d, want 3", info.Tokens)
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,13 @@ func main() {
     // アーカイブファイルの判定
     fmt.Println(IsArchiveFile("data.zip"))   // true
     fmt.Println(IsArchiveFile("backup.tar.gz")) // true
+
+    // ファイル情報の取得
+    info, err := GetFileInfo("sample.txt")
+    if err == nil {
+        fmt.Printf("Type: %s, Size: %d bytes, Tokens: %d\n",
+            info.Type, info.Size, info.Tokens)
+    }
 }
 ```
 
@@ -124,16 +131,16 @@ func main() {
 
 ```
 === ファイル種別判定デモ ===
-ファイル名: document.txt    => テキスト
-ファイル名: photo.jpg       => 画像
-ファイル名: music.mp3       => 音声
-ファイル名: movie.mp4       => 動画
-ファイル名: report.pdf      => ドキュメント
-ファイル名: script.py       => スクリプト
-ファイル名: program.exe     => 実行ファイル
-ファイル名: archive.zip     => アーカイブ
-ファイル名: data.csv        => テキスト
-ファイル名: unknown.xyz     => 不明
+ファイル名: document.txt    => テキスト (ファイルなし)
+ファイル名: photo.jpg       => 画像 (ファイルなし)
+ファイル名: music.mp3       => 音声 (ファイルなし)
+ファイル名: movie.mp4       => 動画 (ファイルなし)
+ファイル名: report.pdf      => ドキュメント (ファイルなし)
+ファイル名: script.py       => スクリプト (ファイルなし)
+ファイル名: program.exe     => 実行ファイル (ファイルなし)
+ファイル名: archive.zip     => アーカイブ (ファイルなし)
+ファイル名: data.csv        => テキスト (ファイルなし)
+ファイル名: unknown.xyz     => 不明 (ファイルなし)
 ```
 
 ## API リファレンス
@@ -150,6 +157,7 @@ func main() {
 | `IsScriptFile(path string) bool` | .sh, .bat, .ps1, .py, .rb, .pl, .js, .ts | ファイルがスクリプトファイルかどうか |
 | `IsExecutableFile(path string) bool` | .exe, .dll, .so, .bin, .app | ファイルが実行ファイルかどうか |
 | `IsArchiveFile(path string) bool` | .zip, .tar, .gz, .bz2, .rar, .7z, .xz, .tar.gz, .tar.bz2, .tar.xz, .tgz, .tbz2, .lz, .lzma, .z, .cab, .arj, .war, .ear | ファイルがアーカイブファイルかどうか |
+| `GetFileInfo(path string) (*FileInfo, error)` | ー | ファイル種別・サイズ・トークン数をまとめて取得 |
 
 ## テスト
 


### PR DESCRIPTION
## Summary
- add FileInfo struct and utilities to detect size and tokens
- update demo to show file size and token count when available
- add unit test for GetFileInfo
- document new GetFileInfo in README with updated output sample

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854c9897630832582f6069f56af0bf7