### PR TITLE
Fix Dockerfile for Alpine runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ COPY . .
 RUN go build -o /work/codepulse ./cmd/main
 
 # Final stage
-FROM scratch
+FROM alpine:3.18 AS runtime
 ARG VERSION
 LABEL org.opencontainers.image.source="https://github.com/miyataSUPER/CodePulse--" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.title="codepulse" \
       org.opencontainers.image.description="File type classifier"
-RUN adduser --disabled-password --disabled-login --home /workdir nonroot \
+RUN adduser -D -h /workdir nonroot \
     && mkdir -p /workdir
 COPY --from=builder /work/codepulse /opt/codepulse/codepulse
 COPY --from=golang:1.21 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt


### PR DESCRIPTION
## Summary
- use alpine for runtime stage
- adjust adduser command for BusyBox

## Testing
- `go test ./... -v`
- `docker build -t codepulse .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854ce481dc88325be9f4c3c499cada0