### PR TITLE
Fix workflow issue and revert to Go 1.20

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: "1.20"
 
       - name: setup just
         uses: extractions/setup-just@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: setup go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.20
 
       - name: setup just
         uses: extractions/setup-just@v1

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"          
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: ./public
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build stage
-FROM golang:1.21 AS builder
+FROM golang:1.20 AS builder
 ARG VERSION
 WORKDIR /src
 COPY . .
@@ -17,7 +17,7 @@ LABEL org.opencontainers.image.source="https://github.com/miyataSUPER/CodePulse-
 RUN adduser -D -h /workdir nonroot \
     && mkdir -p /workdir
 COPY --from=builder /work/codepulse /opt/codepulse/codepulse
-COPY --from=golang:1.21 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=golang:1.20 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 WORKDIR /workdir
 USER nonroot
 ENTRYPOINT ["/opt/codepulse/codepulse"]

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # プロジェクト名: CodePulse++
 ![Status](https://img.shields.io/badge/status-開発中-blue)
-![Go](https://img.shields.io/badge/Go-1.21+-00ADD8?style=flat&logo=go)
+![Go](https://img.shields.io/badge/Go-1.20+-00ADD8?style=flat&logo=go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/miyataSUPER/CodePulse--)](https://goreportcard.com/report/github.com/miyataSUPER/CodePulse--)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
## Summary
- downgrade Go version to 1.20 across docs, Dockerfile and workflows
- bump GitHub Pages artifact action to v2 to avoid deprecated upload-artifact v3

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687039be809c83259346d35f02b251ed